### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Potential fix for [https://github.com/Tech-Preta/learning-dependabot/security/code-scanning/1](https://github.com/Tech-Preta/learning-dependabot/security/code-scanning/1)

To fix the problem, we need to explicitly set a `permissions` block restricting the privileges of the GITHUB_TOKEN for the `build` job, which currently does not declare its own permissions nor inherits any from the workflow root. Since this job only checks out code, installs dependencies, and performs system setup (with no evidence of needing to write to repository resources), we should set minimal permissions: `contents: read` is sufficient. This is best achieved by adding a `permissions:` block with `contents: read` under the `build` job (line 9), ensuring only least-privilege access is granted for this job. No external methods or imports are required; only the yaml is updated.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add minimal GITHUB_TOKEN permissions (contents: read) to the CI build job.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5d6c0c65ff237a8627b7b512768c0bdd183f7d8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas da Versão

* **Nenhuma alteração visível ao usuário**
  * Esta versão contém apenas ajustes internos de infraestrutura que não afetam a experiência do usuário.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->